### PR TITLE
Use docker instead of docker-compose to build and tag the static image.

### DIFF
--- a/idc.Makefile
+++ b/idc.Makefile
@@ -112,7 +112,7 @@ static-drupal-image:
 	EXISTING=`docker images -q $$IMAGE` ; \
 	if test -z "$$EXISTING" ; then \
 	    docker pull $${IMAGE} 2>/dev/null || \
-	    docker-compose build drupal ; \
+	    docker build --build-arg REPOSITORY=$${REPOSITORY} --build-arg TAG=$${TAG} -t $${IMAGE} .; \
 	else \
 	    echo "Using existing Drupal image $${EXISTING}" ; \
 	fi


### PR DESCRIPTION
So this adjustment works for me by removing docker-compose.

If docker-compose is used, my environment requires the build arguments (sans values) to be defined in the docker-compose.yml.  That is fine, but the show-stopper is that the resulting image produced by `make static-drupal-image` is tagged using the idc-isle-buildkit image name (`drupal`) and tag, e.g.:
`ghcr.io/jhu-sheridan-libraries/idc-isle-dc/drupal:upstream-20200824-f8d1e8e-11-gb758f8b` instead of `ghcr.io/jhu-sheridan-libraries/idc-isle-dc/drupal-static:upstream-20201007-739693ae-82-g314440e0`